### PR TITLE
fix(sigpwny): handle virtual meeting venues

### DIFF
--- a/_global/schema/Meeting.ts
+++ b/_global/schema/Meeting.ts
@@ -26,7 +26,7 @@ export const MeetingSchema = ({ image }: SchemaContext) => (
     card_image: z.optional(CardImageSchema(image)).describe('An image representing the meeting.'),
     live_video_url: z.preprocess(
       (arg) => arg === '' ? undefined : arg,
-      z.optional(z.string().url()).describe('A URL to the live video of the meeting (e.g. Zoom).')
+      z.optional(z.string().url()).describe('A URL for joining the meeting live (e.g. Zoom or a Discord voice channel).')
     ),
     slides: z.optional(z.coerce.string()).describe('Relative file path to the slides for the meeting.'),
     recording: z.preprocess(

--- a/sigpwny.com/public/manage/config.yml
+++ b/sigpwny.com/public/manage/config.yml
@@ -97,7 +97,7 @@ collections:
           # {label: 'Background Color', name: 'background_color', widget: 'string', hint: 'Overridden by background image. Include the hashtag. Example: "#33cc55"', required: false},
           {label: 'Alt Text', name: 'alt', widget: 'string', hint: 'Provide a description of the image for accessibility purposes.', required: false}
         ]}
-      - {label: 'Live Video URL (Zoom)', name: 'live_video_url', widget: 'string', hint: 'It is **strongly recommended** to schedule the Zoom meeting in advance so people can find the link before the meeting starts.', required: false}
+      - {label: 'Live Meeting URL', name: 'live_video_url', widget: 'string', hint: 'Use a scheduled Zoom meeting or Discord voice channel URL so people can find the link before the meeting starts.', required: false}
       - {label: 'Recording URL (YouTube)', name: 'recording', widget: 'string', required: false}
       - {label: 'Slides', name: 'slides', widget: 'file', choose_url: false, hint: 'Please upload PDFs instead of PPTX files. If downloading from Google Slides, ensure that skipped slides are not present.', required: false}
       - {label: 'Additional Assets', name: 'assets', widget: 'list', field: {label: File, name: file, widget: 'file', choose_url: false}, hint: 'Zip or compress files together when possible.', required: false}

--- a/sigpwny.com/src/pages/meetings/[...slug]/index.astro
+++ b/sigpwny.com/src/pages/meetings/[...slug]/index.astro
@@ -52,6 +52,7 @@ const time_end = meeting.time_start && meeting.duration
   ? dayjs(meeting.time_start).tz(meeting.timezone).add(dayjs.duration(meeting.duration))
   : undefined;
 const iCalendarLocation = createICalendarLocation(locations, meeting.location);
+const isVirtualLocation = /^(?:discord|online|virtual|zoom)(?:\s+only)?$/i.test(meeting.location?.trim() ?? '');
 ---
 <Layout
   title={`${meeting.semester}${meeting.week_number != null ? ' Week ' + weekNumber(meeting.week_number) : ''}: ${meeting.title} — ${consts.title}`}
@@ -126,10 +127,10 @@ const iCalendarLocation = createICalendarLocation(locations, meeting.location);
           {meeting.location ? (
             <div class="flex flex-row gap-2 items-center">
               <LocationRegular className="flex-none text-primary" />
-              {iCalendarLocation?.title ? (
+              {iCalendarLocation?.title && !isVirtualLocation ? (
                 <a
                   class="inline align-middle !underline underline-offset-2"
-                  href={`https://maps.google.com/?q=${iCalendarLocation.title}`}
+                  href={`https://maps.google.com/?q=${encodeURIComponent(iCalendarLocation.title)}`}
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/sigpwny.com/src/scripts/sync-discord-events.ts
+++ b/sigpwny.com/src/scripts/sync-discord-events.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { Client, GatewayIntentBits, Events, type GuildScheduledEventCreateOptions, GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel, GuildScheduledEvent, type GuildScheduledEventEditOptions, GuildScheduledEventStatus } from 'discord.js';
+import { Client, GatewayIntentBits, Events, type GuildScheduledEventCreateOptions, GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel, GuildScheduledEvent, GuildScheduledEventStatus } from 'discord.js';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
@@ -16,6 +16,11 @@ const zeroPad = (num: any, places: number) => String(num).padStart(places, '0')
 
 // https://stackoverflow.com/a/3809435/5684541
 const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gi;
+
+const getDiscordVoiceChannelId = (url: string | undefined, guildId: string) => {
+    const match = url?.match(/^https:\/\/(?:www\.)?discord\.com\/channels\/(\d+)\/(\d+)\/?$/);
+    return match?.[1] === guildId ? match[2] : undefined;
+};
 
 async function main() {
     const fetchMeetings = async () => {
@@ -99,7 +104,7 @@ async function main() {
         console.log(snowflakeEventLookup);
 
         const meetingsToUpdate = upcomingMeetings.map((meeting: any) : Promise<GuildScheduledEvent> => {
-            const { data : { title, type, location, card_image, week_number, time_end, time_start, description }, body, filePath, slug } = meeting;
+            const { data : { title, type, location, card_image, week_number, time_end, time_start, description, live_video_url }, body, filePath, slug } = meeting;
 
             // Resolve filepath to image
             // const contentDir = path.join(__dirname, '..', '..', path.dirname(filePath));
@@ -114,14 +119,20 @@ async function main() {
 
             const titleWithCategory = meetingMetadata[type]?.shortName ? `${title} [${meetingMetadata[type]?.shortName}]` : title;
             const optionalLocation = location || 'Location TBD';
+            const discordVoiceChannelId = getDiscordVoiceChannelId(live_video_url, guild.id);
 
             const existingMetadata = snowflakeMeetingLookup[noTrailingSlashSlug];
             const metadata : GuildScheduledEventCreateOptions = {
                 description: fullDescription.length > 1000 ? fullDescription.substring(0, 997) + '...' : fullDescription,
-                entityMetadata: {
-                    location: optionalLocation,
-                },
-                entityType: GuildScheduledEventEntityType.External,
+                ...(discordVoiceChannelId ? {
+                    channel: discordVoiceChannelId,
+                    entityType: GuildScheduledEventEntityType.Voice,
+                } : {
+                    entityMetadata: {
+                        location: optionalLocation,
+                    },
+                    entityType: GuildScheduledEventEntityType.External,
+                }),
                 image: cardImageURL || existingMetadata?.coverImageURL({}) || undefined,
                 name: (week_number !== undefined) ? `Week ${zeroPad(week_number, 2)}: ${titleWithCategory}` : titleWithCategory,
                 privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
@@ -134,7 +145,10 @@ async function main() {
                     return Promise.resolve({} as GuildScheduledEvent);
                 }
                 console.log(`Editing meeting "${titleWithCategory}"`);
-                return guild.scheduledEvents.edit(existingMetadata.id, metadata);
+                return guild.scheduledEvents.edit(existingMetadata.id, {
+                    ...metadata,
+                    channel: discordVoiceChannelId ?? null,
+                });
             } else {
                 console.log(`Creating meeting "${titleWithCategory}"`);
                 return guild.scheduledEvents.create(metadata);


### PR DESCRIPTION
## Summary
- render virtual-only meeting locations without Google Maps links while preserving hybrid venue links
- detect Discord voice-channel live URLs when syncing scheduled events
- update meeting schema and Sveltia CMS copy to support Zoom or Discord links

## Verification
- `npm run check`
- `npm run build`
- targeted virtual/hybrid location rendering checks
- targeted Discord channel URL parser checks
- `git diff --check`

Closes #276
Closes #280