### PR TITLE
fix(cms): correct meeting slide path handling

### DIFF
--- a/_global/content/meetings/sp2023/general/2023-02-26/index.mdx
+++ b/_global/content/meetings/sp2023/general/2023-02-26/index.mdx
@@ -7,7 +7,7 @@ credit:
   - Nathan Farlow
 featured: true
 location: Transportation Building 103
-slides: ./Week 05_DSi Hacking.pdf
+slides: ./Week 05_ DSi Hacking.pdf
 recording: https://www.youtube.com/watch?v=wlpW2KYciGU
 tags:
   - pwn

--- a/sigpwny.com/astro.config.ts
+++ b/sigpwny.com/astro.config.ts
@@ -15,7 +15,6 @@ function normalize(filePath: string) {
   return normalizePath(path.resolve(import.meta.dirname, filePath));
 }
 
-const meetingBase = path.resolve(import.meta.dirname, '../_global/content/meetings/');
 type RedirectStatus = 301 | 302 | 307 | 308;
 
 const redirects = redirectData.redirects.reduce<Record<string, {
@@ -94,9 +93,7 @@ export default defineConfig({
           {
             src: normalize('../_global/content/meetings/**/*'),
             dest: 'meetings',
-            rename: (_name, _ext, path) => {
-              return normalizePath(path.replace(meetingBase, '').replace(/(fa|sp)\d{4}/, ''))
-            }
+            rename: { stripBase: 4 },
           }
         ]
       }),

--- a/sigpwny.com/src/pages/[_redirects].ts
+++ b/sigpwny.com/src/pages/[_redirects].ts
@@ -3,7 +3,6 @@ import astroConfig from '~/astro.config';
 const plaintextRedirects = `
 /calendar/full.ics /calendar/all/generic.ics 301
 /calendar/full/apple.ics /calendar/all/apple.ics 301
-/meetings/:semester/:type/:date /meetings/:type/:date 302
 /meetings/fa2017/2017* /meetings/general/2017:splat 302
 /meetings/fa2018/2018* /meetings/general/2018:splat 302
 /meetings/fa2019/2019* /meetings/general/2019:splat 302


### PR DESCRIPTION
## Summary

- Correct the meeting slide filename path for the affected 2023 meeting.
- Simplify meeting asset path handling with `stripBase`.

## Testing

- Not run.